### PR TITLE
Add SushiOperator to zap into Sushi farms

### DIFF
--- a/contracts/defi/SushiOperator.sol
+++ b/contracts/defi/SushiOperator.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.2;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import "../interfaces/sushiswap/IMiniChefV2.sol";
+import "../interfaces/uniswap/IUniswapV2Router02.sol";
+import "../interfaces/uniswap/libraries/UniswapV2Library.sol";
+import "./UniswapOperator.sol";
+
+contract SushiOperator is UniswapOperator, AccessControl {
+  using SafeMath for uint256;
+  using SafeERC20 for IERC20;
+
+  address public immutable factory;
+  IMiniChefV2 public immutable miniChef;
+
+  constructor(
+    address _router,
+    address _factory,
+    address _miniChef
+  ) UniswapOperator(_router) {
+    factory = _factory;
+    miniChef = IMiniChefV2(_miniChef);
+  }
+
+  receive() external payable {}
+
+  function zapIntoSushi(
+    address from,
+    address to,
+    uint256 fromAmount,
+    uint256 minAmountOut,
+    uint256 percentMin,
+    uint256 pid
+  ) public {
+    IERC20(from).safeTransferFrom(msg.sender, address(this), fromAmount);
+    uint256 halfFromAmount = fromAmount / 2;
+    uint256 toAmount = _swapUsingPool(from, to, halfFromAmount, minAmountOut);
+
+    _addLiquidityAndDepositInFarm(
+      from,
+      to,
+      halfFromAmount,
+      toAmount,
+      percentMin,
+      pid
+    );
+
+    // Return leftovers
+    IERC20(from).transfer(msg.sender, IERC20(from).balanceOf(address(this)));
+    IERC20(to).transfer(msg.sender, IERC20(to).balanceOf(address(this)));
+  }
+
+  function _addLiquidityAndDepositInFarm(
+    address token0,
+    address token1,
+    uint256 token0Amount,
+    uint256 token1Amount,
+    uint256 percentMin,
+    uint256 pid
+  ) internal {
+    _addLiquidity(token0, token1, token0Amount, token1Amount, percentMin);
+
+    address lpToken = UniswapV2Library.pairFor(factory, token0, token1);
+    uint256 lpBalance = IERC20(lpToken).balanceOf(address(this));
+    IERC20(lpToken).approve(address(miniChef), lpBalance);
+    miniChef.deposit(pid, lpBalance, msg.sender);
+  }
+}

--- a/contracts/defi/UniswapOperator.sol
+++ b/contracts/defi/UniswapOperator.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import "../interfaces/uniswap/IUniswapV2Router02.sol";
+import "../interfaces/uniswap/libraries/UniswapV2Library.sol";
+
+contract UniswapOperator {
+  using SafeMath for uint256;
+
+  address public immutable router;
+
+  constructor(address _router) {
+    router = _router;
+  }
+
+  function _swapUsingPool(
+    address from,
+    address to,
+    uint256 inputAmount,
+    uint256 minAmountOut
+  ) internal returns (uint256 outAmount) {
+    address[] memory path = new address[](2);
+    path[0] = from;
+    path[1] = to;
+
+    IERC20(from).approve(router, inputAmount);
+    uint256[] memory amounts = IUniswapV2Router02(router)
+      .swapExactTokensForTokens(
+        inputAmount,
+        minAmountOut,
+        path,
+        address(this),
+        block.timestamp
+      );
+    outAmount = amounts[1];
+  }
+
+  function _addLiquidity(
+    address token0,
+    address token1,
+    uint256 token0Amount,
+    uint256 token1Amount,
+    uint256 percentMin
+  ) internal {
+    IERC20(token0).approve(router, token0Amount);
+    IERC20(token1).approve(router, token1Amount);
+    IUniswapV2Router02(router).addLiquidity(
+      token0,
+      token1,
+      token0Amount,
+      token1Amount,
+      (token0Amount * percentMin) / 100,
+      (token1Amount * percentMin) / 100,
+      address(this),
+      block.timestamp
+    );
+  }
+}

--- a/test/sushiOperator.ts
+++ b/test/sushiOperator.ts
@@ -1,0 +1,70 @@
+import { expect } from "chai";
+import { BigNumber } from "ethers";
+import { ethers } from "hardhat";
+import { setupMiniChef } from "./sushiswap";
+import { setupUniswapPools } from "./uniswap";
+import { awaitTx, wei } from "./utils";
+
+describe("SushiSwap Operator", function () {
+  it("Should behave as expected", async function () {
+    const { token0, token1, router, factory, lpToken } =
+      await setupUniswapPools();
+    const { sushi, miniChef } = await setupMiniChef(lpToken);
+
+    const [_, account1] = await ethers.getSigners();
+    await awaitTx(token0.transfer(account1.address, wei(10)));
+
+    const operatorFactory = await ethers.getContractFactory("SushiOperator");
+    const operator = await operatorFactory.deploy(
+      router.address,
+      factory.address,
+      miniChef.address
+    );
+    await operator.deployed();
+
+    await awaitTx(token0.connect(account1).approve(operator.address, wei(10)));
+    await awaitTx(
+      operator
+        .connect(account1)
+        .zapIntoSushi(token0.address, token1.address, wei(10), wei(0), 90, 0)
+    );
+
+    // ASSERTIONS
+
+    const pairFactory = await ethers.getContractFactory("UniswapV2Pair");
+    const lpTokenContract = await pairFactory.attach(lpToken);
+
+    // Operator doesn't have any leftovers.
+    expect(await token0.balanceOf(operator.address)).to.eq(0);
+    expect(await token1.balanceOf(operator.address)).to.eq(0);
+    expect(await lpTokenContract.balanceOf(operator.address)).to.eq(0);
+
+    expect(await lpTokenContract.balanceOf(operator.address)).to.eq(0);
+
+    // Account 1 has a balance in MiniChef.
+    const { amount } = await miniChef.userInfo(0, account1.address);
+    expect(amount).to.gt(0);
+
+    // MiniChef has a balance of lp token.
+    const miniChefBalance = await lpTokenContract.balanceOf(miniChef.address);
+    expect(miniChefBalance).to.gt(0);
+
+    // The balance of token0 and token1 of miniChef is ~5 token0 and ~10 token1.
+    const lpTokenTotalSupply = await lpTokenContract.totalSupply();
+    const { _reserve0, _reserve1 } = await lpTokenContract.getReserves();
+    const lpToken0 = await lpTokenContract.token0();
+    const lpToken1 = await lpTokenContract.token1();
+    const reserve0: BigNumber =
+      lpToken0 === token0.address ? _reserve0 : _reserve1;
+    const reserve1: BigNumber =
+      lpToken1 === token0.address ? _reserve0 : _reserve1;
+    const miniChefShare = miniChefBalance / lpTokenTotalSupply;
+    // Note that passing the BigNumber to string and then to number with the +
+    // is due to limitations on ethers BigNumber. A better way would be cool.
+    const miniChefToken0Balance = +reserve0.toString() * miniChefShare;
+    const miniChefToken1Balance = +reserve1.toString() * miniChefShare;
+    // Zapped in with 10, sold half, ~5 was put in of token0.
+    expect(miniChefToken0Balance).to.gt(+wei(49, 10).toString());
+    expect(miniChefToken1Balance).to.gt(+wei(99, 10).toString());
+  });
+});

--- a/test/sushiswap.ts
+++ b/test/sushiswap.ts
@@ -1,0 +1,22 @@
+import { ethers } from "hardhat";
+import { awaitTx, wei } from "./utils";
+
+export async function setupMiniChef(lpToken: string) {
+  const erc20Factory = await ethers.getContractFactory("MockERC20");
+  const sushi = await erc20Factory.deploy("Mock Sushi", "SUSHI", wei(1000));
+  const miniChefFactory = await ethers.getContractFactory("MiniChefV2");
+  const miniChef = await miniChefFactory.deploy(sushi.address);
+  await miniChef.deployed();
+
+  await awaitTx(
+    miniChef.add(
+      100,
+      lpToken,
+      "0x0000000000000000000000000000000000000000" // rewarder address
+    )
+  );
+  return {
+    sushi,
+    miniChef,
+  };
+}

--- a/test/uniswap.ts
+++ b/test/uniswap.ts
@@ -1,0 +1,42 @@
+import { ethers } from "hardhat";
+import { awaitTx, wei } from "./utils";
+
+export async function setupUniswapPools() {
+  const [owner] = await ethers.getSigners();
+  const erc20Factory = await ethers.getContractFactory("MockERC20");
+  const mockToken0 = await erc20Factory.deploy("Token 0", "T0", wei(100000));
+  const mockToken1 = await erc20Factory.deploy("Token 1", "T1", wei(100000));
+  const eth = await erc20Factory.deploy("Mock Ether", "ETH", wei(100000));
+  await mockToken0.deployed();
+  await mockToken1.deployed();
+  await eth.deployed();
+  const uniFactoryFactory = await ethers.getContractFactory("UniswapV2Factory");
+  const uniRouterFactory = await ethers.getContractFactory("UniswapV2Router02");
+  const factory = await uniFactoryFactory.deploy(owner.address);
+  await factory.deployed();
+  const router = await uniRouterFactory.deploy(factory.address, eth.address);
+  await router.deployed();
+
+  await awaitTx(mockToken0.approve(router.address, wei(50000)));
+  await awaitTx(mockToken1.approve(router.address, wei(50000)));
+  await awaitTx(
+    router.addLiquidity(
+      mockToken0.address,
+      mockToken1.address,
+      wei(10000),
+      wei(20000),
+      wei(10000),
+      wei(20000),
+      owner.address,
+      Date.now() + 60 * 60
+    )
+  );
+  const pair = await factory.allPairs(0);
+  return {
+    token0: mockToken0,
+    token1: mockToken1,
+    router,
+    factory,
+    lpToken: pair,
+  };
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -8,6 +8,8 @@ export async function awaitTx(txPromise: Promise<ContractTransaction>) {
 
 const decimals = BigNumber.from(10).pow(18);
 
-export function wei(value: number) {
-  return BigNumber.from(value).mul(decimals);
+// The divisor is to allow creating decimal numbers, since BigNumber doesn't support it.
+// ie calling wei(25, 10) creates 2.5 wei.
+export function wei(value: number, divisor: number = 1) {
+  return BigNumber.from(value).div(divisor).mul(decimals);
 }


### PR DESCRIPTION
Nuevo contrato `SushiOperator` que hereda de `UniswapOperator`.

Deja entrar con un solo token, vende la mitad por el otro, agrega liquidez y deposita en el farm.

Hay un test que corre localmente.

Próximos pasos:
- Agregar otra función que deje entrar con los dos tokens en vez de uno solo.
- Agregar otra función similar pero que en vez de depositar el lp token en el farm se lo mande al usuario (para Ubeswap).
- Agregar otra función que deje entrar con un token que no sea ninguno de los dos del pool (usando [Swappa](https://github.com/terminal-fi/swappa)? Capaz con caminos hard-codeados)
